### PR TITLE
🩹 fix/콘서트date엔티티디티오추가 그에따른 코드수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,20 +1,17 @@
 import Joi from 'joi';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
-
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
-
 import { AuthModule } from './auth/auth.module';
 import { User } from './user/entities/user.entity';
 import { UserModule } from './user/user.module';
 import { Concert } from './concert/entities/concert.entity';
 import { ConcertModule } from './concert/concert.module';
+import { ConcertDate } from './concert_date/entities/concert_date.entity';
 
 const typeOrmModuleOptions = {
-  useFactory: async (
-    configService: ConfigService,
-  ): Promise<TypeOrmModuleOptions> => ({
+  useFactory: async (configService: ConfigService): Promise<TypeOrmModuleOptions> => ({
     namingStrategy: new SnakeNamingStrategy(),
     type: 'mysql',
     username: configService.get('DB_USERNAME'),
@@ -22,7 +19,7 @@ const typeOrmModuleOptions = {
     host: configService.get('DB_HOST'),
     port: configService.get('DB_PORT'),
     database: configService.get('DB_NAME'),
-    entities: [User, Concert], // 엔티티는 반드시 여기에 명시!
+    entities: [User, Concert, ConcertDate], // 엔티티는 반드시 여기에 명시!
     synchronize: configService.get('DB_SYNC'),
     logging: true,
   }),

--- a/src/concert/concert.controller.ts
+++ b/src/concert/concert.controller.ts
@@ -1,21 +1,31 @@
-import { Controller, Post, Get, Body, UseGuards, Req, Query } from '@nestjs/common';
+import { Controller, Post, Get, Body, UseGuards, Req, Query, Param, ParseIntPipe } from '@nestjs/common';
 import { ConcertService } from './concert.service';
 import { CreateConcertDto } from './dto/create-concert.dto';
 import { GetConcertsDto } from './dto/get-concert.dto';
 import { AuthGuard } from '@nestjs/passport';
+import { Concert } from './entities/concert.entity';
 
 @Controller('concert')
 export class ConcertController {
   constructor(private readonly concertService: ConcertService) {}
 
+  // 새로운 공연을 생성하는 엔드포인트
   @Post()
   @UseGuards(AuthGuard('jwt'))
   async createConcert(@Body() createConcertDto: CreateConcertDto, @Req() req) {
     return this.concertService.createConcert(createConcertDto, req.user.id);
   }
+
+  // 공연의 리스트를 조회하는 엔드포인트, 타이틀/카테고리 필터 적용 가능
   @Get()
-  @UseGuards(AuthGuard('jwt'))
+  // @UseGuards(AuthGuard('jwt'))
   async getConcerts(@Query() filterDto: GetConcertsDto) {
     return this.concertService.getConcerts(filterDto);
+  }
+
+  // 특정 ID의 공연을 조회하는 엔드포인트
+  @Get(':id')
+  async getConcertById(@Param('id', ParseIntPipe) id: number): Promise<Concert> {
+    return this.concertService.getConcertById(id);
   }
 }

--- a/src/concert/concert.module.ts
+++ b/src/concert/concert.module.ts
@@ -4,9 +4,10 @@ import { ConcertController } from './concert.controller';
 import { Concert } from '../concert/entities/concert.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
+import { ConcertDate } from '../concert_date/entities/concert_date.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Concert, User])],
+  imports: [TypeOrmModule.forFeature([Concert, ConcertDate, User])],
   controllers: [ConcertController],
   providers: [ConcertService],
 })

--- a/src/concert/concert.service.ts
+++ b/src/concert/concert.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Concert } from './entities/concert.entity';
@@ -6,49 +6,94 @@ import { CreateConcertDto } from './dto/create-concert.dto';
 import { GetConcertsDto } from './dto/get-concert.dto';
 import { User } from '../user/entities/user.entity';
 import { Role } from '../user/types/userRole.type';
+import { ConcertDate } from '../concert_date/entities/concert_date.entity';
 
 @Injectable()
 export class ConcertService {
   constructor(
     @InjectRepository(Concert)
-    private concertRepository: Repository<Concert>,
+    private concertRepository: Repository<Concert>, // Concert 엔티티를 위한 리포지토리
     @InjectRepository(User)
-    private userRepository: Repository<User>,
+    private userRepository: Repository<User>, // User 엔티티를 위한 리포지토리
+    @InjectRepository(ConcertDate)
+    private concertDateRepository: Repository<ConcertDate>, // ConcertDate 리포지토리 추가
   ) {}
 
+  // 새로운 공연을 생성하는 메소드
   async createConcert(createConcertDto: CreateConcertDto, adminId: number): Promise<Concert> {
+    // 관리자 사용자 찾기
     const adminUser = await this.userRepository.findOneBy({ id: adminId });
 
+    // 관리자가 아닌 경우 예외 발생
     if (!adminUser || adminUser.role !== Role.Admin) {
       throw new UnauthorizedException('관리자 권한이 없습니다.');
     }
 
+    // 공연 날짜가 제공되지 않은 경우 예외 발생
+    if (!createConcertDto.dates || createConcertDto.dates.length === 0) {
+      throw new BadRequestException('공연 날짜를 입력해주세요.');
+    }
+
+    // 새로운 공연 엔티티 생성
     const concert = this.concertRepository.create({
       ...createConcertDto,
       admin_id: adminId,
     });
 
-    return this.concertRepository.save(concert);
+    // 공연 엔티티 저장
+    const savedConcert = await this.concertRepository.save(concert);
+
+    // 공연 날짜 엔티티 생성 및 저장
+    for (const dateDto of createConcertDto.dates) {
+      const concertDate = this.concertDateRepository.create({
+        ...dateDto,
+        concert_id: savedConcert.id,
+      });
+      await this.concertDateRepository.save(concertDate);
+    }
+
+    return savedConcert;
   }
 
-  //   공연의 리스트를 조회합니다
+  // 공연의 리스트를 조회합니다. 타이틀/카테고리를 적으면 조건대로 아니면 전체 조회
   async getConcerts(filterDto: GetConcertsDto): Promise<Concert[]> {
     const { title, category } = filterDto;
     const query = this.concertRepository.createQueryBuilder('concert');
 
     if (title) {
-      //http://localhost:3000/concert?title=New%20Concert 제목이 "New Concert" 일때 예시주소 %20 : 공백표기
+      // http://localhost:3000/concert?title=New%20Concert
+      // 제목이 "New Concert"일 때 예시 주소 (%20 : 공백 표기)
       query.andWhere('concert.title LIKE :title', { title: `%${title}%` });
     }
 
     if (category) {
-      //http://localhost:3000/concert?category=Musical 카테고리별 조회 할때예시
+      // http://localhost:3000/concert?category=Musical
+      // 카테고리별 조회 예시
       query.andWhere('concert.category = :category', { category });
     }
 
+    // 공연 날짜와 조인
+    query.leftJoinAndSelect('concert.dates', 'dates');
+
+    // 쿼리 실행 및 결과 반환
     const concerts = await query.getMany();
     return concerts;
   }
-  //   전체, 공연명 별로 나뉘어서 조회 가능합니다.
-  //  전체조회 , 카테고리 별로 조회 가능하게
+
+  // ID로 공연 상세 조회
+  // 현재 예매가 가능한지 여부를 반환합니다 (seat_count 남으면 예매 가능)
+  async getConcertById(id: number): Promise<Concert> {
+    // ID로 공연 찾기, 공연 날짜 포함
+    const concert = await this.concertRepository.findOne({
+      where: { id },
+      relations: ['dates'], // 공연 날짜를 포함하여 조회
+    });
+
+    // 공연이 없을 경우 예외 발생
+    if (!concert) {
+      throw new NotFoundException(`공연이 존재하지 않습니다.`);
+    }
+
+    return concert;
+  }
 }

--- a/src/concert/dto/create-concert.dto.ts
+++ b/src/concert/dto/create-concert.dto.ts
@@ -1,12 +1,7 @@
-import {
-  IsString,
-  IsInt,
-  IsEnum,
-  IsNotEmpty,
-  IsUrl,
-  IsPositive,
-} from 'class-validator';
+import { IsString, IsInt, IsEnum, IsNotEmpty, IsUrl, IsPositive, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { Category } from '../types/concertCategory.type';
+import { CreateConcertDateDto } from '../../concert_date/dto/create-concert_date.dto';
 
 export class CreateConcertDto {
   @IsInt()
@@ -30,7 +25,7 @@ export class CreateConcertDto {
   location: string;
 
   @IsInt()
-  @IsPositive() //양의 정수만 입력가능함
+  @IsPositive() // 양의 정수만 입력가능함
   @IsNotEmpty({ message: '가격을 입력해주세요.' })
   price: number;
 
@@ -38,8 +33,9 @@ export class CreateConcertDto {
   @IsNotEmpty({ message: '이미지 URL을 입력해주세요.' })
   image: string;
 
-  @IsInt()
-  @IsPositive()
-  @IsNotEmpty({ message: '남은 좌석 수를 입력해주세요.' })
-  seat_count: number;
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateConcertDateDto)
+  @IsNotEmpty({ message: '공연 날짜를 입력해주세요.' }) // 공연 날짜 필수 입력
+  dates: CreateConcertDateDto[]; // 공연 날짜 배열
 }

--- a/src/concert/entities/concert.entity.ts
+++ b/src/concert/entities/concert.entity.ts
@@ -1,8 +1,8 @@
-import { Column, Entity, Index, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
-
+import { Column, Entity, Index, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
 import { Category } from '../types/concertCategory.type';
+import { ConcertDate } from '../../concert_date/entities/concert_date.entity';
 
-@Index('title', ['title'], { unique: true })
+@Index('title', ['title'])
 @Entity({
   name: 'concerts',
 })
@@ -13,7 +13,7 @@ export class Concert {
   @Column({ type: 'int', nullable: false })
   admin_id: number;
 
-  @Column({ type: 'varchar', unique: true, nullable: false })
+  @Column({ type: 'varchar', nullable: false })
   title: string;
 
   @Column({ type: 'varchar', nullable: false })
@@ -36,12 +36,12 @@ export class Concert {
   @Column({ type: 'varchar', nullable: false })
   image: string;
 
-  @Column({ type: 'int', default: 200, nullable: false })
-  seat_count: number;
-
   @CreateDateColumn()
   created_at: Date;
 
   @UpdateDateColumn()
   updated_at: Date;
+
+  @OneToMany(() => ConcertDate, (concertDate) => concertDate.concert)
+  dates: ConcertDate[]; // ConcertDate 엔티티와 일대다 관계 설정
 }

--- a/src/concert_date/dto/create-concert_date.dto.ts
+++ b/src/concert_date/dto/create-concert_date.dto.ts
@@ -1,1 +1,13 @@
-export class CreateConcertDateDto {}
+import { IsDate, IsInt, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateConcertDateDto {
+  @Type(() => Date)
+  @IsDate()
+  @IsNotEmpty()
+  concert_date: Date;
+
+  @IsInt()
+  @IsNotEmpty()
+  seat_count: number;
+}

--- a/src/concert_date/entities/concert_date.entity.ts
+++ b/src/concert_date/entities/concert_date.entity.ts
@@ -1,1 +1,35 @@
-export class ConcertDate {}
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Concert } from '../../concert/entities/concert.entity';
+
+@Entity('concert_dates') // 'concert_dates' 테이블에 매핑되는 엔티티
+export class ConcertDate {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'int', nullable: false })
+  concert_id: number;
+
+  @Column({ type: 'datetime', nullable: false })
+  concert_date: Date;
+
+  @Column({ type: 'int', default: 200, nullable: false })
+  seat_count: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @ManyToOne(() => Concert, (concert) => concert.dates)
+  @JoinColumn({ name: 'concert_id' }) // 외래 키 설정
+  concert: Concert; // Concert 엔티티와 다대일 관계 설정
+}


### PR DESCRIPTION
concert-date안에 seat-count와 dates를 담아서 같은 이름의 공연을 여러번 공연해도 같은 데이터를 최소한으로 찍어내게,  
또 concert에 넣어두면 concert수정한다고 가정하면 다른날짜의 공연도 영향을 받는데 영향을 받지않도록 분리하였습니다
 
